### PR TITLE
fixing turning issues in autpilot and route

### DIFF
--- a/bluesky/traffic/autopilot.py
+++ b/bluesky/traffic/autopilot.py
@@ -242,14 +242,33 @@ class Autopilot(Entity, replaceable=True):
             else:
                 local_next_qdr = bs.traf.actwp.next_qdr[i]
 
+
+            # check if next waypoint has a speed constraint and give that as TAS
+            nextwptspd = bs.traf.actwp.nextspd[i]
+            nextwpalt = bs.traf.actwp.nextaltco[i]
+
+            if nextwptspd > 0 and nextwpalt > 0:
+            # Here there is a speed constraint and altitude constraint
+                nextwpttas = cas2tas(bs.traf.actwp.nextspd[i], bs.traf.actwp.nextaltco[i])
+            elif nextwptspd > 0:
+            # Here there is only a speed constraint
+                nextwpttas = cas2tas(bs.traf.actwp.nextspd[i], bs.traf.alt[i])
+            elif nextwpalt > 0:
+            # if there is only an altitude constraint
+                nextwpttas = cas2tas(bs.traf.cas[i], bs.traf.actwp.nextaltco[i])
+            else:
+                nextwpttas = bs.traf.tas[i]
+
+
             # Calculate turn dist (and radius which we do not use now, but later) now for scalar variable [i]
-            bs.traf.actwp.turndist[i], turnrad, turnspd, turnbank, turnhdgr = \
-                bs.traf.actwp.calcturn(i, bs.traf.tas[i], qdr[i], 
-                                       local_next_qdr, turnbank, 
-                                       turnrad,turnspd,turnhdgr, flyturn, flyby)  # update turn distance for VNAV
+            turndist, turnrad, turnspd, turnbank, turnhdgr = \
+            bs.traf.actwp.calcturn(i, nextwpttas, qdr[i], 
+                                    local_next_qdr, turnbank, 
+                            turnrad,turnspd,turnhdgr, flyturn, flyby)  # update turn distance for VNAV
 
             # Get flyturn switches and data
-            bs.traf.actwp.oldturnspd[i]  = bs.traf.actwp.turnspd[i] # old turnspd, turning by this waypoint
+            bs.traf.actwp.turndist[i]     = turndist * 1.3
+            bs.traf.actwp.oldturnspd[i]   = bs.traf.actwp.turnspd[i] # old turnspd, turning by this waypoint
             bs.traf.actwp.flyturn[i]      = flyturn
             bs.traf.actwp.turnrad[i]      = turnrad
             bs.traf.actwp.turnspd[i]      = turnspd


### PR DESCRIPTION
Hello,

In the current implementation, calcturn() is calculated with the current TAS for FLYOVER and FLYBY waypoints. This means when a waypoint is cleared, the turn distance of the next waypoint is calculated with the current TAS. However, this does not take into account any future speed or altitude constraints that may occur in the next waypoint. This can create either overly long turns or short turns, depending on the constraints.

The current way to calculate turn distances in wppassingcheck() of autopilot.py and direct() of route.py is as follows:
```python
# Calculate turn dist (and radius which we do not use now, but later) now for scalar variable [i]
bs.traf.actwp.turndist[i], turnrad, turnspd, turnbank, turnhdgr = \
bs.traf.actwp.calcturn(i, bs.traf.tas[i], qdr[i], 
                                       local_next_qdr, turnbank, 
                                       turnrad,turnspd,turnhdgr, flyturn, flyby) 
```
I suggest perhaps adding some checks prior to calculating the turn using information already available.

```python
# check if next waypoint has a speed constraint and give that as TAS
nextwptspd = bs.traf.actwp.nextspd[i]
nextwpalt = bs.traf.actwp.nextaltco[i]

if nextwptspd > 0 and nextwpalt > 0:
    # Here there is a speed constraint and altitude constraint
    nextwpttas = cas2tas(bs.traf.actwp.nextspd[i], bs.traf.actwp.nextaltco[i])
elif nextwptspd > 0:
    # Here there is only a speed constraint
    nextwpttas = cas2tas(bs.traf.actwp.nextspd[i], bs.traf.alt[i])
elif nextwpalt > 0:
    # if there is only an altitude constraint
    nextwpttas = cas2tas(bs.traf.cas[i], bs.traf.actwp.nextaltco[i])
else:
    nextwpttas = bs.traf.tas[i]


# Calculate turn dist (and radius which we do not use now, but later) now for scalar variable [i]
bs.traf.actwp.turndist[i], turnrad, turnspd, turnbank, turnhdgr = \
    bs.traf.actwp.calcturn(i, nextwpttas, qdr[i], 
                            local_next_qdr, turnbank, 
                            turnrad,turnspd,turnhdgr, flyturn, flyby)  # update turn distance for VNAV
```

However, perhaps it makes sense to label these waypoints as FLYTURN? In that case, this is probably not needed.

I realised that for the cases where using TAS is more conservative, the turns look nicer. and smoother. However, for the cases where using TAS is not conservative. For example, there is a waypoint constraint with a higher speed than current TAS, then suggested fix has nicer turns. So not sure what the best way forward is.

This also adds a 30 percent increase in turn distance to be safe so that turns are smooth.