### PR TITLE
Fix bug affecting openap aircraft type from defaulting to B744

### DIFF
--- a/bluesky/traffic/performance/openap/perfoap.py
+++ b/bluesky/traffic/performance/openap/perfoap.py
@@ -73,7 +73,7 @@ class OpenAP(PerfBase):
 
         else:
             # convert to known aircraft type
-            if actype not in self.coeff.actypes_fixwing:
+            if actype.lower() not in self.coeff.actypes_fixwing:
                 # warn = f"Warning: {actype} replaced by B744"
                 # print(warn)
                 # stack.echo(warn)


### PR DESCRIPTION
Hello,

There is an issue where all fixing aircraft get the performance values of a B744.

In line 76 of perfoap.py there is a check to convert to a known aircraft type. Even if a valid aircraft type is created, like an A320, the check will fail because the self.coeff.actypes_fixwing list has the A320 listed as a320.

Here is the output of self.coeff.actypes_fixwing

```
['a19n', 'a20n', 'a21n', 'a318', 'a319', 'a320', 'a321', 'a332', 'a333', 'a343', 'a359', 'a388', 'b37m', 'b38m', 'b39m', 'b3xm', 'b734', 'b737', 'b738', 'b739', 'b744', 'b748', 'b752', 'b763', 'b772', 'b773', 'b77w', 'b788', 'b789', 'c550', 'crj9', 'e145', 'e170', 'e190', 'e195', 'e75l', 'glf6', 'a124', 'a306', 'a310', 'at72', 'at75', 'at76', 'b733', 'b735', 'b762', 'b77l', 'c25a', 'c525', 'c56x', 'crj2', 'crj9', 'e290', 'glf5', 'gl5t', 'lj45', 'md11', 'pc24', 'su95']
```

You can verify that all fixing aircraft are B744 by just uncommenting the warn message in line 77 and line 78.

The proposed fix changes the aircraft type to lowercase prior to checking if it is in the known aircraft.
