### PR TITLE
Add aircraft type to screenio

### DIFF
--- a/bluesky/simulation/screenio.py
+++ b/bluesky/simulation/screenio.py
@@ -148,6 +148,7 @@ class ScreenIO(Entity):
         data = dict()
         data['simt']       = bs.sim.simt
         data['id']         = bs.traf.id
+        data['actype']     = bs.traf.type
         data['lat']        = bs.traf.lat
         data['lon']        = bs.traf.lon
         data['alt']        = bs.traf.alt


### PR DESCRIPTION
Here, I add the aircraft type to screenio data being sent by the simulation node. This will be useful for improving the label in WebATM