### PR TITLE
Use canonical altitude values from shape objects in area updates

### DIFF
--- a/bluesky/tools/areafilter.py
+++ b/bluesky/tools/areafilter.py
@@ -61,12 +61,19 @@ def defineArea(name, shape, coordinates, top=1e9, bottom=-1e9):
     elif shape == 'LINE':
         basic_shapes[name] = shapes.Line(name, coordinates)
 
-    # Pass the shape on to the connected clients
+    # Pass the shape on to the connected clients. Read top/bottom back from the
+    # created shape so the live update carries the same canonical values (in
+    # meters, the units aircraft altitudes are sent to clients in) as the
+    # snapshot a reconnecting client receives via Shape.raw. Reading them from
+    # the shape also keeps top/bottom consistent when they are supplied in the
+    # wrong order, since Shape.__init__ sorts them.
     update = dict(shape=shape, coordinates=coordinates)
-    if top < 9e8:
-        update['top'] = top
-    if bottom > -9e8:
-        update['bottom'] = bottom
+    poly = basic_shapes.get(name)
+    if poly is not None:
+        if poly.top < 9e8:
+            update['top'] = poly.top
+        if poly.bottom > -9e8:
+            update['bottom'] = poly.bottom
     polypub.send_update(polys={name: update})
 
     return True  #, f'Created {shape} {name}'


### PR DESCRIPTION
## Summary
Modified the `defineArea` function to read altitude boundaries (top/bottom) from the created shape object rather than using the raw input parameters when sending live updates to connected clients.

## Key Changes
- Changed altitude value source from input parameters (`top`/`bottom`) to the corresponding shape object properties (`poly.top`/`poly.bottom`)
- This ensures live updates sent to clients use the same canonical altitude values that reconnecting clients receive via `Shape.raw`
- Automatically handles cases where top/bottom are supplied in the wrong order, since `Shape.__init__` sorts them internally
- Maintains consistency between real-time updates and snapshot data for reconnecting clients

## Implementation Details
- Retrieves the created shape object from `basic_shapes` dictionary before constructing the update
- Validates the shape exists before accessing its altitude properties
- Preserves the existing threshold logic (9e8 for top, -9e8 for bottom) but applies it to the canonical values from the shape object
- All altitude values are in meters, matching the units used for aircraft altitude transmission to clients

https://claude.ai/code/session_018Z4XZzgP2L1u9Zwd1z4nSV